### PR TITLE
CmdDict Extension Fix and SunRISE GDS Versioning

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -492,7 +492,7 @@ def getDefaultCmdDict(reload=False):
 
 
 def getDefaultDict(reload=False):
-    return util.getDefaultDict(__name__, 'cmddict', CmdDict, reload)
+    return util.getDefaultDict(__name__, 'cmddict', createCmdDict, reload)
 
 
 def getDefaultDictFilename():

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ class DevWithGithooks(develop):
 
 setup(
     name         = 'ait-core',
-    version      = '2.3.5',
+    version      = '1.2.0.0',
     description  = description,
     long_description = long_description,
     long_description_content_type = 'text/x-rst',


### PR DESCRIPTION
Updates `ait.core.cmd.getDefaultDict()` to use the extension-compatible `createCmdDict()` function rather than hard-coded `CmdDict` base object. This ensures that `getDefaultDict()` returns the extended command dictionary object, rather than the AIT base, if such an extension is present.

Also updates the version in `setup.py` to 1.2.0.0 to align with GDS versioning scheme. This aligns with the changes in https://github.jpl.nasa.gov/SunRISE-Ops/SunRISE-AIT/pull/16

The `sunrise` branch will hold all SunRISE changes to AIT Core, and releases will be tagged off of this branch to track GDS releases. `master` will continue to track https://github.com/NASA-AMMOS/AIT-Core, and when releases are tagged there, `master` will be merged into `sunrise` to become part of a SunRISE GDS release.