### PR TITLE
Fix YAMLCtor_include function

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -544,7 +544,7 @@ def YAMLCtor_include(loader, node):
     name = os.path.join(os.path.dirname(loader.name), node.value)
     data = None
     with open(name,'r') as f:
-        data = yaml.load(f)
+        data = yaml.load(f, Loader=yaml.Loader)
     return data
 
 yaml.add_constructor('!include' , YAMLCtor_include)


### PR DESCRIPTION
Explicitly set yaml loader in YAMLCtor_include function in cmd.py module. Without this fix, include blocks in the tlm or cmd dictionaries do not load properly.