### PR TITLE
explicitly set yaml loader in YAMLCtor_include function

### DIFF
--- a/ait/core/cmd.py
+++ b/ait/core/cmd.py
@@ -559,7 +559,7 @@ def YAMLCtor_include(loader, node):  # noqa
     name = os.path.join(os.path.dirname(loader.name), node.value)
     data = None
     with open(name, "r") as f:
-        data = yaml.load(f)
+        data = yaml.load(f, Loader=yaml.Loader)
     return data
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python           = '~3.7'
+python           = '~3.8'
 bottle           = '0.12.17'
 jsonschema       = '3.0.2'
 pyyaml           = '5.1.2'


### PR DESCRIPTION
Without this fix, include blocks in the tlm or cmd dictionaries do not load properly.