### PR TITLE
SRGDS-43 remove apid from tlm.py PacketDefinition

### DIFF
--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -568,7 +568,6 @@ class PacketDefinition(json.SlotSerializer):
         "constants",
         "desc",
         "opcode",
-        "apid",
         "fields",
         "fieldmap",
         "uid",


### PR DESCRIPTION
[SRGDS-43](https://jira.jpl.nasa.gov/browse/SRGDS-43)