### PR TITLE
Fix Field List Comperator

### DIFF
--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -122,8 +122,8 @@ class FieldList(collections.Sequence):
         return (
             isinstance(other, collections.Sequence)
             and len(self) == len(other)
-            and all(self[n] == other[n] for n in range(len(self)))
-        )
+            and all([i == j for (i, j) in zip(self, other)])
+            )
 
     def __getitem__(self, key):
         return self._packet._getattr(self._defn.name, self._raw, key)


### PR DESCRIPTION
Field list comparator was causing Exception "Decoding MSB_F32[197] requires 792
bytes, but the ArrayType.decode() method received only 789 bytes."
Whenever "field_list1 != field_list2" as in AIT-GUI