### PR TITLE
Warn users if a failed dntoeu conversion occured

### DIFF
--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -788,7 +788,7 @@ class PacketExpression:
         except ZeroDivisionError:
             result = None
         except Exception as e:
-            log.debug(f"{__name__} -> Got exception {e} \n"
+            log.error(f"{__name__} -> Got exception {e} \n"
                       f"{__name__} -> Likely cause is FieldList "
                       "dntoeu not being supported with a FieldList as a variable.")
             result = None

--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -787,7 +787,11 @@ class PacketExpression:
             result = eval(self._code, packet._defn.globals, context)
         except ZeroDivisionError:
             result = None
-
+        except Exception as e:
+            log.debug(f"{__name__} -> Got exception {e} \n"
+                      f"{__name__} -> Likely cause is FieldList "
+                      "dntoeu not being supported with a FieldList as a variable.")
+            result = None
         return result
 
     def toJSON(self):  # noqa


### PR DESCRIPTION
dntoeu is not supported whenever one of the variables is a FieldList
This message occurs constantly, so it was pushed to debug.