### PR TITLE
Add state of health subprocessor

### DIFF
--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -502,6 +502,19 @@ class Packet:
             or fieldname in self._defn.derivationmap
         )
 
+    def items(self):
+        d = {name: getattr(self, name) for name in self._defn.fieldmap}
+        for (k, v) in d.items():
+            yield (k, v)
+
+    def keys(self):
+        for i in self._defn.fieldmap:
+            yield i
+
+    def values(self):
+        for i in [getattr(self, name) for name in self._defn.fieldmap]:
+            yield i
+
     @property
     def nbytes(self):
         """The size of this packet in bytes."""

--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -535,6 +535,9 @@ class Packet:
         """
         return self._defn.validate(self, messages)
 
+    def __getitem__(self, k):
+        return PacketContext(self)[k]
+
 
 class PacketContext:
     """PacketContext


### PR DESCRIPTION
The Packet class does not have an iterator.
Add items, keys, values methods so that we can iterate as a map.
It's really messy in here, so we made minimal changes.