### PR TITLE
InfluxDB Add Field List Support

### DIFF
--- a/ait/core/server/plugins/data_archive.py
+++ b/ait/core/server/plugins/data_archive.py
@@ -25,6 +25,7 @@ import ait.core  # noqa
 from ait.core import log, tlm
 from ait.core.server.plugin import Plugin
 
+import traceback
 
 class DataArchive(Plugin):
     def __init__(
@@ -90,3 +91,4 @@ class DataArchive(Plugin):
             self.dbconn.insert(decoded, **kwargs)
         except Exception as e:
             log.error("Data archival failed with error: {}.".format(e))
+            log.error(traceback.print_exc())

--- a/ait/core/tlm.py
+++ b/ait/core/tlm.py
@@ -503,7 +503,7 @@ class Packet:
         )
 
     def items(self):
-        d = {name: getattr(self, name) for name in self._defn.fieldmap}
+        d = {field_name: getattr(self, field_name) for field_name in self._defn.fieldmap}
         for (k, v) in d.items():
             yield (k, v)
 


### PR DESCRIPTION
Fixed Influx Data Processing

Update db.py to support FieldLists

Add additional processing to regular types as well, i.e. unpad string,
bytes and md5 to hex.

tlm functions and dtypes do not function as they should, thus we rely
on looking at the field name for clues as to how we should treat the
value before publishing to influx.

TODO Consider using TaggedPacket where possible.