### PR TITLE
Fix bad log calls

### DIFF
--- a/ait/core/server/plugins/PacketAccumulator.py
+++ b/ait/core/server/plugins/PacketAccumulator.py
@@ -50,7 +50,7 @@ class PacketAccumulator(Plugin,
             for i in self.packet_queue:
                 payload += i
             if not tctf.check_data_field_size(payload):
-                log.error("{self.log_header} created oversized payload.")
+                log.error(f"{self.log_header} created oversized payload.")
             self.publish(payload)
             self.size_packet_queue_octets = 0
             self.packet_queue.clear()

--- a/ait/core/server/plugins/PacketPadder.py
+++ b/ait/core/server/plugins/PacketPadder.py
@@ -29,5 +29,5 @@ class PacketPadder(Plugin,
             fill = bytearray(self.size_pad_octets - len(data))
             data = data + fill
         if not tctf.check_data_field_size(data):
-            log.error(f"{self.logger} created oversized data.")
+            log.error(f"{self.log_header} created oversized data.")
         self.publish(data)


### PR DESCRIPTION
Fixes issue where issuing an oversized command caused an unreported crash that prevents uplinks from being processed.

