### PR TITLE
Add hard exit on plugin failures

### DIFF
--- a/ait/core/server/client.py
+++ b/ait/core/server/client.py
@@ -1,3 +1,4 @@
+import sys
 import gevent
 import gevent.socket
 import gevent.server as gs
@@ -11,6 +12,8 @@ import socket
 import ait.core
 from ait.core import log
 import ait.core.server.utils as utils
+
+STRICT = True
 
 
 class ZMQClient(object):
@@ -111,8 +114,12 @@ class ZMQInputClient(ZMQClient, gevent.Greenlet):
                     continue
 
                 log.debug("{} received message from {}".format(self, topic))
-                self.process(message, topic=topic)
-
+                try:
+                    self.process(message, topic=topic)
+                except Exception as e:
+                    log.error(f"{self} -> encountered uncaught exception: {e} processing message {message}")
+                    if STRICT:
+                        sys.exit(f"Encountered exception while processing message. Now exiting.")
         except Exception as e:
             log.error(
                 "Exception raised in {} while receiving messages: {}".format(self, e)

--- a/ait/core/server/client.py
+++ b/ait/core/server/client.py
@@ -13,8 +13,6 @@ import ait.core
 from ait.core import log
 import ait.core.server.utils as utils
 
-STRICT = True
-
 
 class ZMQClient(object):
     """
@@ -31,6 +29,7 @@ class ZMQClient(object):
         **kwargs,
     ):
 
+        self.exit_on_exception = ait.config.get("server.exit_on_exception", False)
         self.context = zmq_context
         # open PUB socket & connect to broker
         self.pub = self.context.socket(zmq.PUB)
@@ -117,8 +116,8 @@ class ZMQInputClient(ZMQClient, gevent.Greenlet):
                 try:
                     self.process(message, topic=topic)
                 except Exception as e:
-                    log.error(f"{self} -> encountered uncaught exception: {e} processing message {message}")
-                    if STRICT:
+                    log.error(f"encountered uncaught exception: {e} processing message {message}")
+                    if self.exit_on_exception:
                         sys.exit(f"Encountered exception while processing message. Now exiting.")
         except Exception as e:
             log.error(

--- a/ait/core/server/server.py
+++ b/ait/core/server/server.py
@@ -11,6 +11,9 @@ from .broker import Broker
 from ait.core import log, cfg
 import copy
 import traceback
+import sys
+
+STRICT = True
 
 
 class Server(object):
@@ -361,6 +364,8 @@ class Server(object):
                     )
                     log.error(f"{__name__} Error instantiating plugin: "
                               f"{plugin}{traceback.format_exc()}")
+                    if STRICT:
+                        sys.exit("Encountered uncaught exception while instantiating plugins.\n Now exiting.")
             if not self.plugins:
                 log.warn(
                     "No valid plugin configurations found. No plugins will be added."

--- a/ait/core/server/server.py
+++ b/ait/core/server/server.py
@@ -13,8 +13,6 @@ import copy
 import traceback
 import sys
 
-STRICT = True
-
 
 class Server(object):
     """
@@ -24,6 +22,7 @@ class Server(object):
     """
 
     def __init__(self):
+        self.exit_on_exception = ait.config.get("server.exit_on_exception", False)
         self.broker = Broker()
 
         self.inbound_streams = []
@@ -362,9 +361,9 @@ class Server(object):
                     log.error(
                         "{} creating plugin {}: {}".format(exc_type, index, value)
                     )
-                    log.error(f"{__name__} Error instantiating plugin: "
+                    log.error(f"Error instantiating plugin: "
                               f"{plugin}{traceback.format_exc()}")
-                    if STRICT:
+                    if self.exit_on_exception:
                         sys.exit("Encountered uncaught exception while instantiating plugins.\n Now exiting.")
             if not self.plugins:
                 log.warn(


### PR DESCRIPTION
Add hard exit when plugin fails to initialize or an uncaught exception occurs.
This can be disabled by developers by setting the STRICT flag to false.