### PR TITLE
Rework logging

### DIFF
--- a/ait/core/sdls_utils.py
+++ b/ait/core/sdls_utils.py
@@ -1,0 +1,42 @@
+from enum import Enum, auto
+import ait
+import logging
+
+log = logging.getLogger(__name__)
+
+def get_sdls_type():
+    config_prefix = 'dsn.sle.tctf.'
+    """
+    Return SDLS type from config.yaml
+    """
+    log_header = __name__ + "-> get_sdls_type=>"
+    
+    try:
+        sdls_type_str = ait.config.get(config_prefix+'expected_sdls_type', None)
+        sdls_type = SDLS_Type[sdls_type_str]
+    except AttributeError:
+        #  Config not ready
+        return SDLS_Type.ENC
+    except Exception as e:
+        print(e)
+        sdls_type = None
+        log.debug(f"{log_header} Got None. {ait.config.get('dsn.sle.tctf.expected_sdls_type')}")
+    if not sdls_type: 
+        log.warn(f"{log_header} {config_prefix}expected_sdls_type parameter "
+                 "was not found on config.yaml <CLEAR|AUTH|ENC>. "
+                 "Assuming ENC.")
+        sdls_type = SDLS_Type.ENC
+
+    log.debug(f"found SDLS_Type: {sdls_type}")
+    return sdls_type
+
+class SDLS_Type(Enum):
+    CLEAR = auto()
+    ENC = auto()  # Authenticated Encryption (SDLS)
+    AUTH = auto()  # Authentication Only (SDLS)
+    # FINAL is for internal use.
+    # It is treated the same as CLEAR
+    # Used by Encrypter to signify that TCTF size check
+    # should be done against final TCTF size instead of
+    # the KMC hand off size that it must necessarily violate.
+    FINAL = auto()

--- a/ait/core/server/plugins/PacketPadder.py
+++ b/ait/core/server/plugins/PacketPadder.py
@@ -1,15 +1,13 @@
 from ait.core.server.plugins import Plugin
 from ait.core import log
-import ait.dsn.plugins.TCTF_Manager as tctf
+from ait.dsn.plugins.TCTF_Manager import check_data_field_size, get_max_data_field_size
 import ait.dsn.plugins.Graffiti as Graffiti
-
 
 class PacketPadder(Plugin,
                    Graffiti.Graphable):
     def __init__(self, inputs=None, outputs=None, zmq_args=None, **kwargs):
         super().__init__(inputs, outputs, zmq_args)
-        self.logger_header = __name__ + " ->"
-        self.size_pad_octets = tctf.get_max_data_field_size()
+        self.size_pad_octets = get_max_data_field_size()
         Graffiti.Graphable.__init__(self)
 
     def graffiti(self):
@@ -22,12 +20,13 @@ class PacketPadder(Plugin,
         
     def process(self, data, topic=None):
         if not data:
-            log.error(f"{self.log_header} received no data from {topic}.")
-        if not tctf.check_data_field_size(data):
-            log.error(f"{self.log_header} initial data from {topic} is oversized.")
+            log.error(f"received no data from {topic}.")
+        if not check_data_field_size(data):
+            log.error(f"initial data from {topic} is oversized.")
         if len(data) < self.size_pad_octets:
             fill = bytearray(self.size_pad_octets - len(data))
             data = data + fill
-        if not tctf.check_data_field_size(data):
-            log.error(f"{self.logger} created oversized data.")
+        if not check_data_field_size(data):
+            log.error(f"created oversized data.")
+        log.debug(f"publishing payload of size: {len(data)}")
         self.publish(data)


### PR DESCRIPTION
- Prevent users from accidentally logging clear and encrypted frames
simultaneously
- Add filter to remove annoying messages during startup and debug
- Move SDLS_Type, get_sdls_type into core module to avoid circular dependency