### PR TITLE
Add various mitigations for decoding errors when packet loss occurs

### DIFF
--- a/ait/core/db.py
+++ b/ait/core/db.py
@@ -385,7 +385,7 @@ class InfluxDBBackend(GenericBackend):
             fields[field_name] = val
 
         if len(fields) == 0:
-            log.error("No fields present to insert into Influx")
+            log.debug("No fields present to insert into Influx")
             return
 
         tags = kwargs.get("tags", {})

--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -258,7 +258,16 @@ class PrimitiveType(object):
         ``decode()`` inteface, but has no effect for PrimitiveType
         definitions.
         """
-        return struct.unpack(self.format, memoryview(bytestring))[0]
+        try:
+            res = struct.unpack(self.format, memoryview(bytestring))[0]
+            return res
+        except IndexError as e:
+            raise e
+        except struct.error as e:
+            raise e
+        except Exception as e:
+            log.error(e)
+            raise e
 
     def toJSON(self):  # noqa
         return self.name

--- a/ait/core/server/process.py
+++ b/ait/core/server/process.py
@@ -245,12 +245,12 @@ class PluginsProcess(object):
         Args:
             namespace: AIT process namespace
         """
-        plugin_proc_name = f"plugin-process.{namespace}"
+        plugin_proc_name = f"ait-server.{namespace}"
 
         updated_title = f"ait-server-{plugin_proc_name}"
         orig_title = setproctitle.getproctitle()
         if orig_title is not None:
-            updated_title = f"{orig_title} {plugin_proc_name}"
+            updated_title = f"{plugin_proc_name}"
 
         setproctitle.setproctitle(updated_title)
 

--- a/ait/core/server/server.py
+++ b/ait/core/server/server.py
@@ -3,7 +3,9 @@ import gevent.monkey
 
 from importlib import import_module
 import sys
+import os
 import traceback
+import atexit
 
 import ait.core.server
 from .stream import PortInputStream, ZMQStream, PortOutputStream
@@ -12,6 +14,7 @@ from .broker import Broker
 from .plugin import PluginType, Plugin, PluginConfig
 from .process import PluginsProcess
 from ait.core import log, cfg
+
 
 gevent.monkey.patch_all()
 
@@ -52,6 +55,7 @@ class Server(object):
             + self.broker.inbound_streams
             + self.broker.outbound_streams
         )
+        atexit.register(self.shutdown)
 
     def wait(self):
         """
@@ -495,3 +499,8 @@ class Server(object):
                                                            zmq_args)
 
         return plugin_config
+
+    def shutdown(self):
+        for i in self.plugin_process_dict.values():
+            i.abort()
+        os._exit(0)


### PR DESCRIPTION
- Fix error in message types where S3 paths were assigned to failed
uploads
- Made proctitle more manageable for plugin processes
- kill plugin processes on exit
- Return empty dict whenever packet decoding fails
- raise value error whenever a packet field is converted to an unknown
enum