### PR TITLE
Fix Field Arrays

### DIFF
--- a/ait/core/data/tlm_schema.json
+++ b/ait/core/data/tlm_schema.json
@@ -70,6 +70,9 @@
                         "units": {
                             "type": "string"
                         },
+						"dynamic": {
+                            "type": "string"
+                        },
                         "desc": {
                             "type": "string"
                         },

--- a/ait/core/db.py
+++ b/ait/core/db.py
@@ -341,17 +341,9 @@ class InfluxDBBackend(GenericBackend):
         # TODO: Python 3.9 -> tags = tags | alarm_tags
         tags = {**alarm_tags, **tags}
 
-        # time.format = 'iso'
-        # fields['AIT_time_gps'] = str(time)
-
-        # time.format = 'gps'
-        # time_ns = int(float(str(time))*1E9)
-
         time.format = 'iso'
         time = time.datetime.isoformat("T") + "Z"
         data = {"time": time, "measurement": name, "tags": tags, "fields": fields}
-        
-        
         self._conn.write_points([data])
 
     def _query(self, query, **kwargs):

--- a/ait/core/dtype.py
+++ b/ait/core/dtype.py
@@ -353,6 +353,9 @@ class ArrayType(object):
         if index < 0 or index >= self.nelems:
             raise IndexError("list index out of range")
 
+    def fundamental_type(self):
+        return self.type
+
     @property
     def name(self):
         """Name of this ArrayType."""


### PR DESCRIPTION
 # Field Arrays
  + Dynamic arrays now supported with the _dynamic_ flag in telemetry
  configs. Set its value to a previous field that dictates how large
  the dynamic array is.

  Example:

    - !Field
      name:  file_data_len
      desc:  "Length of the file_data field"
      type:  MSB_U32
      bytes: [1, 4]
      units: unitless

    - !Field
      name:  file_data
      desc:  "Contains a binary data segment of dynamic length"
      type:  U8[100000]
      bytes: [4, 10004]
      units: binary
      dynamic: file_data_len

 ## New Canonical Forms
    + The telemetry field flag _units: binary_ makes the canonical form of the array a base64 dump
    + Fields with fieldname containing _bytes_ or _md5_ is a hex
	string dump.
	+ All other array fields are represented by a CSV string
	+ TODO: Do this utilizing _units:bytes_ instead